### PR TITLE
Add lhdocs as a command in the command line

### DIFF
--- a/scripts/lhdocs
+++ b/scripts/lhdocs
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python -m lhdocs $*

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     licence=licence,
     zip_safe=False,
     packages=[package],
+    scripts=['scripts/lhdocs'],
     install_requires=['beautifulsoup4==4.3.2'],
     classifiers=[
         'Development Status :: 1 - Development',


### PR DESCRIPTION
I added `lhdocs` as a shell script. Using lhdocs.py was impossible because of import errors. It would try to import itself instead of the main package.
